### PR TITLE
Fix: Correct routing for Report page and add Vercel SPA config

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,8 +22,9 @@ function App() {
     <Route path='/about' element={<About />} />
     <Route path='/signup' element={<Register />} />
     <Route path='/blog' element={<Blog />} />
+    <Route path='/report' element={<Report />} />
     <Route path='*' element={<h1>404 Not Found</h1>} />
-    <Route path='/predict' element={< Report/>} />
+    {/* It's generally better to have the catch-all route last */}
     </Routes>
     </BrowserRouter>
   </>

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- Changed the route for the Report component in App.jsx from '/predict' to '/report'.
- Added frontend/vercel.json with standard SPA rewrite rules to ensure proper client-side routing on Vercel.
- This resolves the 404 error when accessing the /report path.